### PR TITLE
Clickable commands features

### DIFF
--- a/src/main/java/com/festp/Main.java
+++ b/src/main/java/com/festp/Main.java
@@ -29,7 +29,7 @@ public class Main extends JavaPlugin
 		Config config = new Config(this, lang);
 		config.load();
 
-		StyledMessageBuilderFactory factory = new TheStyledMessageBuilderFactory(config, new SpigotCommandValidator());
+		StyledMessageBuilderFactory factory = new TheStyledMessageBuilderFactory(config, new SpigotCommandValidator(config));
 		MessageSender messageSender = new SpigotMessageSender(this, config);
 		Chatter chatter = new RawJsonChatter(config, factory, messageSender);
 

--- a/src/main/java/com/festp/commands/LinksCommand.java
+++ b/src/main/java/com/festp/commands/LinksCommand.java
@@ -99,7 +99,6 @@ public class LinksCommand implements CommandExecutor, TabCompleter
 				key = k;
 				break;
 			}
-		System.out.println(key == null ? "null" : key.name());
 		if (key == null) return;
 		
 		if (key.getValueClass() == Boolean.class) {

--- a/src/main/java/com/festp/config/Config.java
+++ b/src/main/java/com/festp/config/Config.java
@@ -27,7 +27,7 @@ public class Config implements IConfig
 	public DisplaySettings getDisplaySettings() {
 		return new DisplaySettings(
 				get(Key.UNDERLINE_LINKS), get(Key.UNDERLINE_COMMANDS), get(Key.UNDERLINE_COPYABLE_TEXT),
-				get(Key.TOOLTIP_LINKS), get(Key.TOOLTIP_COMMANDS), get(Key.TOOLTIP_COPYABLE_TEXT));
+				get(Key.TOOLTIP_LINKS), get(Key.TOOLTIP_COMMANDS), get(Key.TOOLTIP_COPYABLE_TEXT), get(Key.COMMANDS_RUN_ON_CLICK));
 	}
 	
 	public void load() {
@@ -127,6 +127,7 @@ public class Config implements IConfig
 		TOOLTIP_COPYABLE_TEXT("tooltip-copyable-text", "Copy text"),
 		
 		COMMANDS_REMOVE_STARTING_DOT("commands-remove-starting-dot", true),
+		COMMANDS_RUN_ON_CLICK("commands-run-on-click", false),
 		
 		COPYABLE_TEXT_BEGIN_QUOTES("copyable-text-begin-quotes", ",,"),
 		COPYABLE_TEXT_END_QUOTES("copyable-text-end-quotes", ",,"),

--- a/src/main/java/com/festp/config/Config.java
+++ b/src/main/java/com/festp/config/Config.java
@@ -130,6 +130,7 @@ public class Config implements IConfig
 		
 		COPYABLE_TEXT_BEGIN_QUOTES("copyable-text-begin-quotes", ",,"),
 		COPYABLE_TEXT_END_QUOTES("copyable-text-end-quotes", ",,"),
+		COPYABLE_TEXT_ONLY_COMMANDS("copyable-text-only-commands", false),
 		
 		LISTEN_TO_WHISPER("do-whisper", true),
 		WHISPER_SEPARATE_MESSAGE("whisper-separate-message", false);

--- a/src/main/java/com/festp/messaging/DisplaySettings.java
+++ b/src/main/java/com/festp/messaging/DisplaySettings.java
@@ -6,6 +6,8 @@ public class DisplaySettings
 	public final boolean underlineCommands;
 	public final boolean underlineCopyableText;
 
+	public final boolean runCommands;
+	
 	public final String tooltipLinks;
 	public final String tooltipCommands;
 	public final String tooltipCopyableText;
@@ -16,11 +18,13 @@ public class DisplaySettings
 			boolean underlineCopyableText,
 			String tooltipLinks,
 			String tooltipCommands,
-			String tooltipCopyableText)
+			String tooltipCopyableText,
+			boolean runCommands)
 	{
 		this.underlineLinks = underlineLinks;
 		this.underlineCommands = underlineCommands;
 		this.underlineCopyableText = underlineCopyableText;
+		this.runCommands = runCommands;
 		this.tooltipLinks = tooltipLinks;
 		this.tooltipCommands = tooltipCommands;
 		this.tooltipCopyableText = tooltipCopyableText;

--- a/src/main/java/com/festp/messaging/RawJsonBuilder.java
+++ b/src/main/java/com/festp/messaging/RawJsonBuilder.java
@@ -124,11 +124,9 @@ public class RawJsonBuilder
 	{
 		String plainName = player.getName();
 		String uuid = player.getPlayer().getUniqueId().toString();
-		StringBuilder eventsJson = new StringBuilder()
-				.append("\"hoverEvent\":{\"action\":\"show_text\",\"value\":\"" + plainName + "\\nType: Player\\n" + uuid + "\"},")
-				.append("\"clickEvent\":{\"action\":\"suggest_command\",\"value\":\"/tell " + plainName + " \"},");
-		
-		json.append(eventsJson);
+		String tooltip = plainName + "\\nType: Player\\n" + uuid;
+		json.append(getSuggestCommandJson("/tell " + plainName + " "));
+		json.append(getShowTextJson(tooltip));
 	}
 	
 	private void appendTextStyle(StringBuilder text, StringBuilder json, TextStyle style) {
@@ -161,20 +159,42 @@ public class RawJsonBuilder
 	private void appendCommand(StringBuilder text, StringBuilder json, Command command) {
 		if (settings.underlineCommands)
 			text.append(ChatColor.UNDERLINE);
-		json.append(getSuggestCommandJson(command.getCommand(), settings.tooltipCommands));
+		
+		if (settings.runCommands)
+			json.append(getRunCommandJson(command.getCommand()));
+		else
+			json.append(getSuggestCommandJson(command.getCommand()));
+		
+		json.append(getShowTextJson(settings.tooltipCommands));
 	}
 	
 	private void appendCopyableText(StringBuilder text, StringBuilder json, CopyableText copyableText) {
 		if (settings.underlineCopyableText)
 			text.append(ChatColor.UNDERLINE);
-		json.append(getSuggestCommandJson(copyableText.getText(), settings.tooltipCopyableText));
+		json.append(getSuggestCommandJson(copyableText.getText()));
+		json.append(getShowTextJson(settings.tooltipCopyableText));
 	}
 	
-	private static String getSuggestCommandJson(String command, String tooltip) {
+	private static String getSuggestCommandJson(String command) {
 		StringBuilder eventsJson = new StringBuilder();
 		eventsJson.append("\"clickEvent\":{\"action\":\"suggest_command\",\"value\":\"")
 		          .append(command)
 		          .append("\"},");
+		
+		return eventsJson.toString();
+	}
+	
+	private static String getRunCommandJson(String command) {
+		StringBuilder eventsJson = new StringBuilder();
+		eventsJson.append("\"clickEvent\":{\"action\":\"run_command\",\"value\":\"")
+		          .append(command)
+		          .append("\"},");
+		
+		return eventsJson.toString();
+	}
+	
+	private static String getShowTextJson(String tooltip) {
+		StringBuilder eventsJson = new StringBuilder();
 		if (!tooltip.isEmpty())
 			eventsJson.append("\"hoverEvent\":{\"action\":\"show_text\",\"value\":\"")
 			          .append(tooltip)

--- a/src/main/java/com/festp/messaging/RawJsonChatter.java
+++ b/src/main/java/com/festp/messaging/RawJsonChatter.java
@@ -11,6 +11,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 
+import com.festp.Logger;
 import com.festp.config.Config;
 import com.festp.styledmessage.SingleStyleMessage;
 import com.festp.styledmessage.StyledMessage;
@@ -44,7 +45,7 @@ public class RawJsonChatter implements Chatter
 	{
 		StyledMessageBuilder builder = factory.create();
 		StyledMessage styledMessage = builder.append(message).build();
-		if (!canSend(styledMessage))
+		if (!canSend(styledMessage, message))
 			return false;
 		
 		if (sendToConsole)
@@ -95,7 +96,7 @@ public class RawJsonChatter implements Chatter
 	{
 		StyledMessageBuilder builder = factory.create();
 		StyledMessage styledMessage = builder.append(message).build();
-		if (!canSend(styledMessage))
+		if (!canSend(styledMessage, message))
 			return false;
 		
 		String fromStr = "commands.message.display.outgoing"; // "You whisper to %s: %s"
@@ -138,7 +139,7 @@ public class RawJsonChatter implements Chatter
 	{
 		StyledMessageBuilder builder = factory.create();
 		StyledMessage styledMessage = builder.append(message).build();
-		if (!canSend(styledMessage))
+		if (!canSend(styledMessage, message))
 			return false;
 		
 		Iterable<Link> links = getLinks(styledMessage);
@@ -207,7 +208,7 @@ public class RawJsonChatter implements Chatter
 		return links;
 	}
 	
-	private static boolean canSend(StyledMessage styledMessage)
+	private static boolean canSend(StyledMessage styledMessage, String originalText)
 	{
 		if (styledMessage == null)
 			return false;
@@ -216,6 +217,13 @@ public class RawJsonChatter implements Chatter
 			for (TextComponent component : part.getComponents())
 				if (!(component instanceof TextStyle))
 					return true;
+		
+		StringBuilder text = new StringBuilder();
+		for (SingleStyleMessage part : styledMessage.getStyledParts())
+			text.append(part.getText());
+		
+		if (!text.toString().equals(ChatColor.stripColor(originalText)))
+			return true;
 		
 		return false;
 	}

--- a/src/main/java/com/festp/parsing/CopyableTextParser.java
+++ b/src/main/java/com/festp/parsing/CopyableTextParser.java
@@ -62,7 +62,7 @@ public class CopyableTextParser implements ComponentParser
 	
 	private TextComponent getComponent(String s)
 	{
-		if (s.startsWith("/") && commandValidator.commandExists(s.split(" ")[0])) {
+		if (commandValidator.commandExists(s.split(" ")[0])) {
 			return new Command(s);
 		}
 		if (onlyCommands) {

--- a/src/main/java/com/festp/styledmessage/TheStyledMessageBuilderFactory.java
+++ b/src/main/java/com/festp/styledmessage/TheStyledMessageBuilderFactory.java
@@ -25,17 +25,38 @@ public class TheStyledMessageBuilderFactory implements StyledMessageBuilderFacto
 	@Override
 	public StyledMessageBuilder create()
 	{
-		List<ComponentParser> globalParsers = Lists.newArrayList(new TextStyleParser());
+		List<ComponentParser> globalParsers = Lists.newArrayList(getTextStyleParser());
 		
 		List<ComponentParser> splittingParsers = Lists.newArrayList();
 		if (config.get(Key.ENABLE_COPYABLE_TEXT, false))
-			splittingParsers.add(new CopyableTextParser(config.get(Key.COPYABLE_TEXT_BEGIN_QUOTES), config.get(Key.COPYABLE_TEXT_END_QUOTES)));
+			splittingParsers.add(getCopyableTextParser());
 		if (config.get(Key.ENABLE_LINKS, false))
-			splittingParsers.add(new LinkParser());
+			splittingParsers.add(getLinkParser());
 		if (config.get(Key.ENABLE_COMMANDS, false))
-			splittingParsers.add(new CommandParser(commandValidator, config.get(Key.COMMANDS_REMOVE_STARTING_DOT, true)));
+			splittingParsers.add(getCommandParser());
 		
 		return new TheStyledMessageBuilder(globalParsers, splittingParsers);
 	}
-
+	
+	private ComponentParser getTextStyleParser()
+	{
+		return new TextStyleParser();
+	}
+	
+	private ComponentParser getCopyableTextParser()
+	{
+		return new CopyableTextParser(
+				config.get(Key.COPYABLE_TEXT_BEGIN_QUOTES), config.get(Key.COPYABLE_TEXT_END_QUOTES),
+				config.get(Key.COPYABLE_TEXT_ONLY_COMMANDS), commandValidator);
+	}
+	
+	private ComponentParser getLinkParser()
+	{
+		return new LinkParser();
+	}
+	
+	private ComponentParser getCommandParser()
+	{
+		return new CommandParser(commandValidator, config.get(Key.COMMANDS_REMOVE_STARTING_DOT, true));
+	}
 }

--- a/src/main/java/com/festp/styledmessage/components/TextStyle.java
+++ b/src/main/java/com/festp/styledmessage/components/TextStyle.java
@@ -80,7 +80,7 @@ public class TextStyle implements UpdatableTextComponent {
 
 	/** @return <b>"color":"gray","italic":"true",</b><br>
 	 * if object is TextSyle of ChatColor.GRAY.toString() + ChatColor.ITALIC.toString()*/
-	public Object getFullJson() {
+	public String getFullJson() {
 		String styleStr = getCodes();
 		StringBuilder res = new StringBuilder();
 		res.append(getJson());

--- a/src/main/java/com/festp/utils/SpigotCommandValidator.java
+++ b/src/main/java/com/festp/utils/SpigotCommandValidator.java
@@ -7,15 +7,27 @@ import org.bukkit.Bukkit;
 import org.bukkit.help.HelpTopic;
 
 import com.festp.Logger;
+import com.festp.config.Config;
+import com.festp.config.Config.Key;
 
 public class SpigotCommandValidator implements CommandValidator
 {
+	private final Config config;
+	
 	// lazy initialization
 	private Collection<String> commands = new HashSet<>();
 	
+	public SpigotCommandValidator(Config config) {
+		this.config = config;
+	}
+	
 	@Override
 	public boolean commandExists(String command) {
-		if (commands.isEmpty()) commands = getCommands();
+		if (commands.isEmpty()) {
+			commands = getCommands();
+			if (config.get(Key.LOG_DEBUG, true)) // TODO Logger.canLog(level)
+				Logger.info("Found commands: " + String.join(", ", commands));
+		}
 		
 		if (command.charAt(0) != '/') return false;
         return commands.contains(command.substring(1));
@@ -40,7 +52,6 @@ public class SpigotCommandValidator implements CommandValidator
                 }
             }
         }
-		Logger.info("Found commands: " + String.join(", ", commandsAndAliases));
 		return commandsAndAliases;
 	}
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -21,6 +21,8 @@ do-whisper: true
 whisper-separate-message: false
 
 commands-remove-starting-dot: true
+commands-run-on-click: false
 
 copyable-text-begin-quotes: ',,'
 copyable-text-end-quotes: ',,'
+copyable-text-only-commands: false


### PR DESCRIPTION
New configuration options: `commands-run-on-click` and `copyable-text-only-commands`
Console flood fixes